### PR TITLE
Adding features like serviceAccountName for OpenShift security constr…

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: postgresql
   repository: https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
   version: 8.9.9
-digest: sha256:526629d1646df6a72d4414adc89f3728f0e97e37a4e8ac65036c51e06361c7bb
-generated: "2022-06-22T22:35:06.775527-05:00"
+digest: sha256:9bf0731393755a97be066c786f40dd92f7a640137658a129a37c29cedd7d6560
+generated: "2023-02-27T22:24:29.970340243-07:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
 - name: postgresql
   version: ~8.9
   repository:  https://raw.githubusercontent.com/bitnami/charts/pre-2022/bitnami
-  condition: postgres.enabled
+  condition: postgresql.enabled
 
 annotations:
   artifacthub.io/links: |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ The following table lists the configurable parameters of the Bety chart and thei
 | `betyPassword`                       | Password value for bety.password                                              | `bety`                                                  |
 | `betyDatabase`                       | Name of the database for bety.database                                        | `bety`                                                  |
 
+### OpenShift/Kubernetes parameters
+
+| Parameter                         | Description                                              | Default                        |
+|-----------------------------------|----------------------------------------------------------|--------------------------------|
+| `serviceAccount.enabled`          | Enable creation and use of a deployment service account  | false                          |
+| `serviceAccount.name`             | Add a serviceAccountName to the deployment               | ``                             |
+| `serviceAccount.annotations`      | Add annotations to the serviceAccount                    | {}                             |
+
 ### Ingress parameters
 
 | Parameter                         | Description                                              | Default                        |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -25,6 +25,23 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Create a default service account name.
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "serviceAccount.fullname" -}}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "betydb.chart" -}}
@@ -74,6 +91,8 @@ Environment variables for PostgreSQL
   value: {{ include "betydb.postgresqlHost" . | quote }}
 - name: PGPORT
   value: {{ include "betydb.postgresqlPort" . | quote }}
+- name: PGDATABASE
+  value: {{ .Values.postgresql.postgresqlDatabase | default "postgres" | quote }}
 - name: PGUSER
   value: {{ .Values.postgresql.postgresqlUsername | default "postgres" | quote }}
 - name: PGPASSWORD

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -100,6 +100,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ include "serviceAccount.fullname" . | quote }}
+      {{- end }}
     {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.externalSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,3 +12,4 @@ data:
 {{- end }}
   betyPassword:  {{ .Values.betyPassword | b64enc | quote }}
   secretKey:  {{ .Values.secretKey | b64enc | quote }}
+{{- end }}

--- a/templates/serviceAccount.yaml
+++ b/templates/serviceAccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "serviceAccount.fullname" . }}
+  labels:
+    {{- include "betydb.labels" . | nindent 4 }}
+  annotations:
+  {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -39,6 +39,11 @@ betyDatabase: bety
 ## changed users will not be able to login with their existing passwords.
 secretKey: thisisnotasecret
 
+## Set to true if you will be managing the `betydb` secret with external secrets. 
+## The `betydb` secret includes `betyPassword`, `postgresqlPassword`, 
+## and `secretKey`.
+externalSecret: false
+
 ## dbtag is the tag of the database to load. Normally will use latest to
 ## make sure latest tag is loaded, this might not work with an older database.
 ## set this to "" to not load the database
@@ -107,6 +112,9 @@ postgresql:
   ## not saved in the database.
   postgresqlPassword: supersecret
 
+  ## postgresqlDatabase postgresql database to connect to load the database
+  postgresqlDatabase: postgres
+
   # need more space
   persistence:
     size: 20Gi
@@ -168,6 +176,21 @@ resources: {}
 ## Node selector
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
+
+serviceAccount:
+
+  # Specifies whether a service account should be added to the deployment
+  enabled: false
+
+  # Specifies whether a service account should be created
+  create: false
+
+  # Annotations to add to the service account
+  annotations: {}
+
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
 
 ## Tolerations
 ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/


### PR DESCRIPTION
…aints

parent 9cc554112c075c1a994205d50c08e0366afb00d7
author Christopher Tate <computate@computate.org> 1677561053 -0700 committer Christopher Tate <computate@computate.org> 1677684028 -0700

- fix a bug with postgresql.enabled value
- add optional serviceAccount to deployment for required security on OpenShift
- add docs for the new serviceAccount values
- allow customizing the postgresqlDatabase value and PGDATABASE environment variable on the betydb container
- allow disabling the creation of a betydb Secret in order to use an ExternalSecret from a vault instead